### PR TITLE
Add stricter permissions to irida.conf and web.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,6 +186,9 @@ class irida(
     path    => '/etc/irida/irida.conf',
     require => File['/etc/irida'],
     notify  => Service['tomcat'],
+    owner   => $tomcat_user,
+    group   => $tomcat_group,
+    mode    => '0600',
   }
 
   file { 'web.conf':
@@ -194,6 +197,9 @@ class irida(
     path    => '/etc/irida/web.conf',
     require => File['/etc/irida'],
     notify  => Service['tomcat'],
+    owner   => $tomcat_user,
+    group   => $tomcat_group,
+    mode    => '0600',
   }
 
   file { '/etc/irida/plugins':


### PR DESCRIPTION
Previously, `irida.conf` and `web.conf` would be world-readable. Because these files store secrets such as login credentials for various services, we should ensure these files can only be read by users who require access, namely, the tomcat user.