### PR TITLE
Add Puppet Bolt Task for upgrading to new IRIDA version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     * [What irida affects](#what-irida-affects)
     * [Setup requirements](#setup-requirements)
     * [Beginning with irida](#beginning-with-irida)
+    * [Upgrading irida](#upgrading-irida)
 3. [Usage - Configuration options and additional functionality](#usage)
 4. [Limitations - OS compatibility, etc.](#limitations)
 5. [Development - Guide for contributing to the module](#development)
@@ -30,6 +31,31 @@ The simplest way to get IRIDA up and running with the IRIDA module is to run wit
 include '::irida'
 ```
 
+### Upgrading irida
+
+> **[Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt.html) is required to
+> use the upgrade task.**
+
+The `upgrade` task included in this module can be used to upgrade the IRIDA
+instance to a newer version. This task accepts no parameters and instead
+relies on the file managed by the module located at `/irida_upgrade.config`
+on the target host, allowing for the upgrade process to automatically retrieve
+credentials and other information that it requires.
+
+In order to perform a system upgrade using the `upgrade` task and Puppet Bolt:
+
+1. Apply the IRIDA module with the `irida_version` parameter set to the version
+   of IRIDA that you wish to upgrade to. See available version numbers on the
+   [IRIDA download page](https://github.com/phac-nml/irida/releases/).
+2. Run the upgrade task using Puppet Bolt:  
+   `bolt task run -i <inventory file>  -t <target host> irida::upgrade`
+
+The upgrade task performs the following actions:
+
+1. Stop the `puppet` and `tomcat` services
+2. Dump the database to a backup file located at `~tomcat/irida-<date>.dbbackup`
+3. Delete the old `irida.war` file and replaces it with the version specified
+4. Start the `puppet` and `tomcat` services
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ include '::irida'
 
 The `upgrade` task included in this module can be used to upgrade the IRIDA
 instance to a newer version. This task accepts no parameters and instead
-relies on the file managed by the module located at `/irida_upgrade.config`
+relies on the file managed by the module located at `/etc/irida/irida_upgrade.config`
 on the target host, allowing for the upgrade process to automatically retrieve
 credentials and other information that it requires.
 
@@ -53,9 +53,9 @@ In order to perform a system upgrade using the `upgrade` task and Puppet Bolt:
 The upgrade task performs the following actions:
 
 1. Stop the `puppet` and `tomcat` services
-2. Dump the database to a backup file located at `~tomcat/irida-<date>.dbbackup`
+2. Dump the database to a backup file located at `/tmp/irida-<date>.dbbackup` by default 
 3. Delete the old `irida.war` file and replaces it with the version specified
-4. Start the `puppet` and `tomcat` services
+4. Start the `puppet` services
 
 ## Limitations
 

--- a/examples/irida.yaml
+++ b/examples/irida.yaml
@@ -14,6 +14,7 @@ irida::db_user: irida
 irida::db_password: REALLYstrongPASSWORDsoGOOD!!!!1!
 irida::db_name: irida
 irida::db_host: 127.0.0.1
+irida::db_backup_location: '/tmp'
 irida::nfs_based: false
 irida::sequence_directory: "%{lookup('irida::data_directory')}/sequence"
 irida::reference_directory: "%{lookup('irida::data_directory')}/reference"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,7 +233,7 @@ class irida(
     notify  => Service['tomcat'],
   }
 
-  file { '/irida_upgrade.config':
+  file { '/etc/irida/irida_upgrade.config':
     ensure  => 'present',
     content => template('irida/irida_upgrade.config.erb'),
     owner   => root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class irida(
   String  $tomcat_logs_location = "${tomcat_location}logs",
   String  $irida_ip_addr        = 'localhost',
   String  $irida_version        = '20.01.2', #release tags  https://github.com/phac-nml/irida/releases
+  String  $war_url              = "https://github.com/phac-nml/irida/releases/download/${irida_version}/irida-${irida_version}.war",
 
   Boolean       $splunk_index_logs       = false,
   String        $splunk_receiver         = 'my-splunk-receiver-example.com',
@@ -143,7 +144,7 @@ class irida(
 
 
   tomcat::war { 'irida.war':
-    war_source    => "https://github.com/phac-nml/irida/releases/download/${irida_version}/irida-${irida_version}.war",
+    war_source    => $war_url,
     catalina_base => '/opt/tomcat/',
     user          => $tomcat_user,
     group         => $tomcat_group,
@@ -212,6 +213,14 @@ class irida(
     path    => '/etc/irida/analytics/google-analytics.html',
     require => File['/etc/irida/analytics'],
     notify  => Service['tomcat'],
+  }
+
+  file { '/irida_upgrade.config':
+    ensure  => 'present',
+    content => template('irida/irida_upgrade.config.erb'),
+    owner   => root,
+    group   => root,
+    mode    => '0400'
   }
 
   if $nfs_based {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,11 +22,12 @@ class irida(
     "${tomcat_logs_location}/catalina.out"
   ],
 
-  Boolean $make_db     = true,
-  String  $db_user     = 'irida',
-  String  $db_name     = 'irida',
-  String  $db_password = 'irida',
-  String  $db_host     = '127.0.0.1',
+  Boolean $make_db            = true,
+  String  $db_user            = 'irida',
+  String  $db_name            = 'irida',
+  String  $db_password        = 'irida',
+  String  $db_host            = '127.0.0.1',
+  String  $db_backup_location = '/tmp/',
 
   Integer $file_upload_max_size        = 16106127360,
   Integer $file_processing_core        = 4,
@@ -238,6 +239,14 @@ class irida(
     owner   => root,
     group   => root,
     mode    => '0400'
+  }
+
+  file { '/etc/my.cnf':
+    ensure  => 'present',
+    content => template('irida/my.cnf.erb'),
+    owner   => root,
+    group   => root,
+    mode    => '0600'
   }
 
   if $nfs_based {

--- a/tasks/upgrade.json
+++ b/tasks/upgrade.json
@@ -1,0 +1,3 @@
+{
+  "description": "Upgrades IRIDA to the version specified by the hieradata"
+}

--- a/tasks/upgrade.sh
+++ b/tasks/upgrade.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-. /irida_upgrade.config
+. /etc/irida/irida_upgrade.config
 
 echo "Stopping services..."
 systemctl stop puppet

--- a/tasks/upgrade.sh
+++ b/tasks/upgrade.sh
@@ -9,17 +9,20 @@ systemctl stop puppet
 systemctl stop tomcat
 
 echo "Dumping database..."
-echo $db_password | su tomcat -c $tomcat_user mysqldump -h $db_host -u $db_user $db_name > ~tomcat/irida.dbbackup
-chmod 0600 ~tomcat/irida.dbbackup
-chown $tomcat_user:$tomcat_group ~tomcat/irida.dbbackup
-mv ~tomcat/irida.dbbackup ~tomcat/irida-$(date  +"%y-%m-%d-%T").dbbackup
+#Root user
+mysqldump  $db_name > /tmp/irida.dbbackup
+chmod 0600 /tmp/irida.dbbackup
+chown $tomcat_user:$tomcat_group /tmp/irida.dbbackup
+#######
+
+#execute move as user to ensure permission are preserved if location is on NFS
+sudo -u $tomcat_user mv /tmp/irida.dbbackup $db_backup_location/irida-$(date  +"%y-%m-%d-%T").dbbackup
 
 echo "Replacing WAR file..."
 sudo -u $tomcat_user rm $tomcat_location/webapps/irida.war
 sudo -u $tomcat_user curl -o $tomcat_location/webapps/irida.war $war_url
 
 echo "Starting services..."
-systemctl start tomcat
 systemctl start puppet
 
 echo "done"

--- a/tasks/upgrade.sh
+++ b/tasks/upgrade.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+. /irida_upgrade.config
+
+echo "Stopping services..."
+systemctl stop puppet
+systemctl stop tomcat
+
+echo "Dumping database..."
+echo $db_password | su tomcat -c $tomcat_user mysqldump -h $db_host -u $db_user $db_name > ~tomcat/irida.dbbackup
+chmod 0600 ~tomcat/irida.dbbackup
+chown $tomcat_user:$tomcat_group ~tomcat/irida.dbbackup
+mv ~tomcat/irida.dbbackup ~tomcat/irida-$(date  +"%y-%m-%d-%T").dbbackup
+
+echo "Replacing WAR file..."
+sudo -u $tomcat_user rm $tomcat_location/webapps/irida.war
+sudo -u $tomcat_user curl -o $tomcat_location/webapps/irida.war $war_url
+
+echo "Starting services..."
+systemctl start tomcat
+systemctl start puppet
+
+echo "done"

--- a/tasks/upgrade.sh
+++ b/tasks/upgrade.sh
@@ -23,6 +23,8 @@ sudo -u $tomcat_user rm $tomcat_location/webapps/irida.war
 sudo -u $tomcat_user curl -o $tomcat_location/webapps/irida.war $war_url
 
 echo "Starting services..."
+#only restarting puppet since it will start tomcat for us
+#want to avoid a potential race condition
 systemctl start puppet
 
 echo "done"

--- a/templates/irida_upgrade.config.erb
+++ b/templates/irida_upgrade.config.erb
@@ -1,8 +1,6 @@
 tomcat_location=<%= @tomcat_location %>
 db_name=<%= @db_name %>
 tomcat_user=<%= @tomcat_user %>
-db_user=<%= @db_user %>
-db_group=<%= @db_group %>
-db_password=<%= @db_password %>
-db_host=<%= @db_host %>
+tomcat_group=<%= @tomcat_group %>
+db_backup_location=<%= @db_backup_location %>
 war_url=<%= @war_url %>

--- a/templates/irida_upgrade.config.erb
+++ b/templates/irida_upgrade.config.erb
@@ -1,6 +1,6 @@
-tomcat_location=<%= @tomcat_location %>
 db_name=<%= @db_name %>
+db_backup_location=<%= @db_backup_location %>
 tomcat_user=<%= @tomcat_user %>
 tomcat_group=<%= @tomcat_group %>
-db_backup_location=<%= @db_backup_location %>
+tomcat_location=<%= @tomcat_location %>
 war_url=<%= @war_url %>

--- a/templates/irida_upgrade.config.erb
+++ b/templates/irida_upgrade.config.erb
@@ -1,0 +1,8 @@
+tomcat_location=<%= @tomcat_location %>
+db_name=<%= @db_name %>
+tomcat_user=<%= @tomcat_user %>
+db_user=<%= @db_user %>
+db_group=<%= @db_group %>
+db_password=<%= @db_password %>
+db_host=<%= @db_host %>
+war_url=<%= @war_url %>

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -1,0 +1,4 @@
+[mysqldump]
+user=<%= @db_user %>
+password=<%= @db_password %>
+host=<%= @db_host %>


### PR DESCRIPTION
This PR adds a Puppet Bolt [task](https://puppet.com/docs/puppet/6.17/bolt_tasks.html) for upgrading the IRIDA instance.

See the included documentation for more information.