### PR TITLE
Add parameter to set URL path for the IRIDA instance

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class irida(
   String  $tomcat_logs_location = "${tomcat_location}/logs",
   String  $irida_ip_addr        = 'localhost',
   String  $irida_version        = '20.01.2', #release tags  https://github.com/phac-nml/irida/releases
+  String  $irida_url_path       = 'irida',
 
   Boolean       $splunk_index_logs       = false,
   String        $splunk_receiver         = 'my-splunk-receiver-example.com',
@@ -95,6 +96,7 @@ class irida(
     ssl_server_cert      => $irida::ssl_server_cert,
     ssl_chainbundle_cert => $irida::ssl_chainbundle_cert,
     ssl_cert_private_key => $irida::ssl_cert_private_key,
+    irida_url_path       => $irida::irida_url_path,
   }
 
   if $manage_user {

--- a/manifests/web_server.pp
+++ b/manifests/web_server.pp
@@ -10,6 +10,7 @@ class irida::web_server (
   String  $ssl_chainbundle_cert = '',
   String  $ssl_cert_private_key = '',
   String  $irida_ip_addr = $ipaddress,
+  String  $irida_url_path = 'irida',
 ) {
 
   ensure_resource('package', 'epel-release', {'ensure' => 'present'})

--- a/templates/ngs.conf.erb
+++ b/templates/ngs.conf.erb
@@ -35,7 +35,7 @@ RequestHeader set X-Forwarded-Proto "https"
 
 	# REST API:
 	# IRIDA REST API (deployed to $TOMCAT_HOME/webapps/ as irida-web.war):
-	<Location /irida>
+	<Location /<%= @irida_url_path %>>
 	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
 	</Location>
 
@@ -68,7 +68,7 @@ RequestHeader set X-Forwarded-Proto "https"
 
 	# REST API:
 	# IRIDA REST API (deployed to $TOMCAT_HOME/webapps/ as irida-web.war):
-	<Location /irida>
+	<Location /<%= @irida_url_path %>>
 	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
 	</Location>
 </VirtualHost>


### PR DESCRIPTION
Internally, the path to the IRIDA instance will still be `localhost:8080/irida`, but with this new parameter, the URL that reverse proxies the IRIDA instance can have its path configured, rather than always being `/irida`.