### PR TITLE
Add `force_ssl` parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class irida(
   String $irida_disabled_workflow      = '',
 
   Boolean $use_ssl              = false,
+  Boolean $force_ssl            = false,
   String  $ssl_server_cert      = '',
   String  $ssl_chainbundle_cert = '',
   String  $ssl_cert_private_key = '',
@@ -92,6 +93,7 @@ class irida(
   class {'irida::web_server':
     irida_ip_addr        => $irida::irida_ip_addr,
     apache_use_ssl       => $irida::use_ssl,
+    apache_force_ssl     => $irida::force_ssl,
     ssl_server_cert      => $irida::ssl_server_cert,
     ssl_chainbundle_cert => $irida::ssl_chainbundle_cert,
     ssl_cert_private_key => $irida::ssl_cert_private_key,

--- a/manifests/web_server.pp
+++ b/manifests/web_server.pp
@@ -6,6 +6,7 @@
 #   include irida::web_server
 class irida::web_server (
   Boolean $apache_use_ssl = false,
+  Boolean $apache_force_ssl = false,
   String  $ssl_server_cert = '',
   String  $ssl_chainbundle_cert = '',
   String  $ssl_cert_private_key = '',

--- a/templates/ngs.conf.erb
+++ b/templates/ngs.conf.erb
@@ -1,4 +1,5 @@
-<% if @apache_use_ssl %>
+<% if @apache_use_ssl -%>
+<% if @apache_force_ssl -%>
 # Redirect Client HTTP traffic to HTTPS
 LoadModule rewrite_module modules/mod_rewrite.so
 RewriteEngine On 
@@ -10,6 +11,7 @@ Header edit Location ^http://(.*)$ https://$1
 
 # Make sure links are generated in HTTPS
 RequestHeader set X-Forwarded-Proto "https"
+<% end -%>
 
 <VirtualHost *:443>
 	ServerName 		http://<%= @irida_ip_addr %>
@@ -44,7 +46,8 @@ RequestHeader set X-Forwarded-Proto "https"
 	ProxyPassReverse /proxy-error http://<%= @irida_ip_addr %>:81/proxy-error
 	
 </VirtualHost>
-<% else %>
+<% end %>
+<% if !@apache_use_ssl or !@apache_force_ssl -%>
 <VirtualHost *:80>
 	ServerName		http://<%= @irida_ip_addr %>
 	ErrorLog 		/var/log/httpd/irida.ajp.error.log
@@ -72,4 +75,4 @@ RequestHeader set X-Forwarded-Proto "https"
 	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
 	</Location>
 </VirtualHost>
-<% end %>
+<% end -%>


### PR DESCRIPTION
When this parameter is set to `false`, the Apache server will accept sessions on both
HTTPS and HTTP. When it is set to `true`, the Apache server will transform all HTTP
requests into HTTPS requests, which, prior to this commit, was the default behaviour
when `use_ssl` was set to `true`.