### PR TITLE
Fix custom `irida_url_path` values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,7 +146,7 @@ class irida(
   }
 
 
-  tomcat::war { 'irida.war':
+  tomcat::war { "${irida_url_path}.war":
     war_source    => "https://github.com/phac-nml/irida/releases/download/${irida_version}/irida-${irida_version}.war",
     catalina_base => '/opt/tomcat/',
     user          => $tomcat_user,
@@ -240,7 +240,7 @@ class irida(
         provider => 'shell',
         creates  => $dir,
         user     => $irida::tomcat_user,
-        require  => [Tomcat::Install[$tomcat_location],Tomcat::War['irida.war'],User[$tomcat_user]],
+        require  => [Tomcat::Install[$tomcat_location],Tomcat::War["${irida_url_path}.war"],User[$tomcat_user]],
       }
     }
   }
@@ -250,7 +250,7 @@ class irida(
       path    => $irida::data_directory,
       owner   => $tomcat_user,
       group   => $tomcat_group,
-      require => [Tomcat::Install[$tomcat_location],Tomcat::War['irida.war']]
+      require => [Tomcat::Install[$tomcat_location],Tomcat::War["${irida_url_path}.war"]]
     }
 
     file { 'irida ref':

--- a/templates/ngs.conf.erb
+++ b/templates/ngs.conf.erb
@@ -14,7 +14,7 @@ RequestHeader set X-Forwarded-Proto "https"
 <% end -%>
 
 <VirtualHost *:443>
-	ServerName 		http://<%= @irida_ip_addr %>
+	ServerName 		https://<%= @irida_ip_addr %>
 	ErrorLog 		/var/log/httpd/irida.ajp.error.log
 	CustomLog 		/var/log/httpd/irida.ajp.log combined
 	ErrorDocument	503	/proxy-error/503.html
@@ -32,13 +32,13 @@ RequestHeader set X-Forwarded-Proto "https"
 	</Proxy>
 
 	ProxyPreserveHost 	On
-	ProxyPass 			/ 	http://<%= @irida_ip_addr %>:8080/irida
-	ProxyPassReverse 	/ 	http://<%= @irida_ip_addr %>:8080/irida
+	ProxyPass 			/ 	http://<%= @irida_ip_addr %>:8080/<%= @irida_url_path %>
+	ProxyPassReverse 	/ 	http://<%= @irida_ip_addr %>:8080/<%= @irida_url_path %>
 
 	# REST API:
 	# IRIDA REST API (deployed to $TOMCAT_HOME/webapps/ as irida-web.war):
 	<Location /<%= @irida_url_path %>>
-	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
+	    ProxyPass http://<%= @irida_ip_addr %>:8080/<%= @irida_url_path %> connectiontimeout=7200 timeout=7200
 	</Location>
 
 	# Custom error pages
@@ -66,13 +66,13 @@ RequestHeader set X-Forwarded-Proto "https"
 	ProxyPassReverse	/proxy-error	http://<%= @irida_ip_addr %>:81/proxy-error
 
 	<Location />
-	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
+	    ProxyPass http://<%= @irida_ip_addr %>:8080/<%= @irida_url_path %> connectiontimeout=7200 timeout=7200
 	</Location>
 
 	# REST API:
 	# IRIDA REST API (deployed to $TOMCAT_HOME/webapps/ as irida-web.war):
 	<Location /<%= @irida_url_path %>>
-	    ProxyPass http://<%= @irida_ip_addr %>:8080/irida connectiontimeout=7200 timeout=7200
+	    ProxyPass http://<%= @irida_ip_addr %>:8080/<%= @irida_url_path %> connectiontimeout=7200 timeout=7200
 	</Location>
 </VirtualHost>
 <% end -%>

--- a/templates/web.conf.erb
+++ b/templates/web.conf.erb
@@ -2,9 +2,9 @@
 # used by the e-mailer when sending out e-mail notifications (password resets,
 # for example) and embeds this URL directly in the body of the e-mail.
 <% if @use_ssl %>
-server.base.url=https://<%= @irida_ip_addr %>/irida
+server.base.url=https://<%= @irida_ip_addr %>/<%= @irida_url_path %>
 <% else %>
-server.base.url=http://<%= @irida_ip_addr %>/irida
+server.base.url=http://<%= @irida_ip_addr %>/<%= @irida_url_path %>
 <% end %>
 
 # Mail server configuration settings


### PR DESCRIPTION
Previously, the functionality of setting a custom URL path for the IRIDA instance was broken because the `irida.war` file was not renamed to `${irida_url_path}.war`. This meant that `httpd` would accept connections from the custom URL, but then re-adjust the URL to match the proxied URL (which is dictated by the name of the WAR file.) 

Paths in the `httpd` configuration and IRIDA `web.conf` also need to be updated to expect tomcat to serve from the custom path.