### PR TITLE
add java web tokens for version 22.09+

### DIFF
--- a/examples/irida.yaml
+++ b/examples/irida.yaml
@@ -50,6 +50,9 @@ irida::irida_workflow_max_running: 4
 irida::irida_analysis_cleanup_days: 15
 irida::irida_scheduled_subscription_cron: '0 0 0 * * *'
 irida::security_password_expiry: -1
+irida::jwk_key_store_path: '/etc/irida/jwk-key-store.jks'
+irida::jwk_key_store_file: 'BASE64_OF_BINARY_ENCRYPTED_AS_WELL'
+irida::jwk_key_store_password: 'NOTSECRETATALL'
 irida::irida_scheduled_threads: 2
 
 

--- a/templates/irida.conf.erb
+++ b/templates/irida.conf.erb
@@ -71,6 +71,10 @@ jdbc.pool.maxIdle=10
 ## Configure the password expiry time in days.  A value of -1 will set no expiry.
 security.password.expiry=<%= @security_password_expiry %>
 
+# The location of the Java Key Store
+oauth2.jwk.key-store=<%= @jwk_key_store_path %>
+# The Java Key Store password
+oauth2.jwk.key-store-password=<%= @jwk_key_store_password %>
 
 # Name of command line linker to appear when selecting in export dropdown
 ngsarchive.linker.script=<%= @linker_script %>


### PR DESCRIPTION
IRIDA version 22.09+ needs to have a java web token (jwk) file and password present otherwise will not start up tomcat. 

If no file is given, puppet module will auto-generate one. 

[Admin documentation](https://github.com/phac-nml/irida/blob/development/doc/administrator/web/index.md#oauth2-jwk-java-key-store-generation)

Upgrading instruction from previous version of [IRIDA](https://github.com/phac-nml/irida/blob/development/UPGRADING.md#2205-to-2209)