### PR TITLE
Use `ensure_packages` rather than `ensure_resource`

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -8,7 +8,7 @@ class irida::database (
 ){
 
   if $make_db {
-    ensure_resource('package', 'epel-release', {'ensure' => 'present'})
+    ensure_packages(['epel-release'], {'ensure' => 'present'})
 
     package { 'mariadb-server':
       ensure  => 'present',

--- a/manifests/web_server.pp
+++ b/manifests/web_server.pp
@@ -14,7 +14,7 @@ class irida::web_server (
   String  $irida_url_path = 'irida',
 ) {
 
-  ensure_resource('package', 'epel-release', {'ensure' => 'present'})
+  ensure_packages(['epel-release'], {'ensure' => 'present'})
 
   package { 'mod_ssl':
     ensure => 'present'


### PR DESCRIPTION
This corrects the duplicate resource definition errors that occur with this module on Puppet 7.