### PR TITLE
fix package name for alma 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,7 +80,7 @@ class irida(
   Boolean $ncbi_upload_ftp_passive                              = true,
 
 ){
-  ensure_packages (['epel-release','python3-pip','python3-devel','python-virtualenv'],{'ensure' => 'present'})
+  ensure_packages (['epel-release','python3-pip','python3-devel','python3-virtualenv'],{'ensure' => 'present'})
   ensure_packages ( [ 'java-11-openjdk'],{'ensure' => 'present',
   require => Package['epel-release']})
 


### PR DESCRIPTION
python-virtualenv was renamed to python3-virtualenv in alma 8. I didn't have push permissions on this repo, so I had to make a fork to make this PR.