### PR TITLE
Remove deprecated use of systemd Puppet module's `daemon_reload`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,10 +143,11 @@ class irida(
     mode    => '0644',
     content => template('irida/tomcat.service.erb'),
     require => Tomcat::Install[$tomcat_location],
-  } -> Class['systemd::systemctl::daemon_reload']
+  }
 
   service { 'tomcat':
     ensure    => 'running',
+    enable    => true,
     subscribe => File['/etc/systemd/system/tomcat.service'],
   }
 


### PR DESCRIPTION
This usage was a relic from the Puppet 4 and 5 days, and has not been needed for a long time. It was [officially dropped](https://github.com/voxpupuli/puppet-systemd/commit/97dd16fa32886b5b0f77a6f38a4953d4c1511c0e) from the systemd module in 2021, so if we want to use a modern version of that module we have to update this.