### PR TITLE
Don't use SSLv2 or v3 on port 443

### DIFF
--- a/templates/ngs.conf.erb
+++ b/templates/ngs.conf.erb
@@ -10,6 +10,7 @@
 	SSLCertificateFile 		/etc/ssl/certs/server.crt
 	SSLCertificateChainFile /etc/ssl/certs/chainbundle.crt
 	SSLCertificateKeyFile 	/etc/ssl/certs/server.key
+	SSLProtocol all -SSLv2 -SSLv3
 
 	<Proxy *>
 		AddDefaultCharset Off


### PR DESCRIPTION
These protocols are no longer considered secure. HTTPD's default `ssl.conf` disables them, and we should as well.